### PR TITLE
Speed up webpack compiling

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "react-helmet": "^5.2.0",
-    "styled-components": "^3.3.2"
+    "styled-components": "^3.3.2",
+    "watchpack": "^1.6.0"
   },
   "scripts": {
     "start": "node scripts/start.js",
@@ -70,8 +71,7 @@
     "typescript": "^2.9.1",
     "url-loader": "^1.0.1",
     "webpack": "^4.12.0",
-    "webpack-dev-server": "2.9.4",
-    "webpack-watch-files-plugin": "^1.0.2"
+    "webpack-dev-server": "2.9.4"
   },
   "jest": {
     "transform": {

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -9,7 +9,6 @@ process.env.NODE_ENV = 'development';
 
 const options = {
   contentBase: './dist',
-  hot: true,
   host: 'localhost',
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,17 +3,23 @@ const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const WatchExternalFilesPlugin = require('webpack-watch-files-plugin').default;
+const Watchpack = require('watchpack');
 
 // get tuture path
 const tuturePath = process.env.TUTURE_PATH;
 
+const wp = new Watchpack({
+  aggregateTimeout: 1000,
+  poll: true,
+  ignored: /node_modules/,
+});
+
+wp.watch([`${tuturePath}/tuture.yml`], [], Date.now() - 10000);
+
 module.exports = {
-  entry: [
-    './scripts/polyfills.js',
-    './src/index.tsx',
-  ],
+  entry: ['./scripts/polyfills.js', './src/index.tsx'],
   devtool: 'inline-source-map',
+  mode: 'development',
   output: {
     filename: '[name].bundle.js',
     path: path.resolve(__dirname, 'dist'),
@@ -22,17 +28,15 @@ module.exports = {
     extensions: ['.js', '.json', '.ts', '.tsx'],
   },
   plugins: [
-    new WatchExternalFilesPlugin({
-      files: [
-        `${tuturePath}/tuture.yml`,
-      ],
+    new HtmlWebpackPlugin({
+      filename: 'index.html',
+      template: 'dist/index.html',
     }),
     new CopyWebpackPlugin([
       { from: `${tuturePath}/tuture.yml`, to: './tuture.yml' },
       { from: `${tuturePath}/.tuture/diff`, to: './diff' },
     ]),
     new webpack.NamedModulesPlugin(),
-    new webpack.HotModuleReplacementPlugin(),
   ],
   module: {
     strictExportPresence: true,
@@ -47,16 +51,11 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        use: [
-          'style-loader',
-          'css-loader',
-        ],
+        use: ['style-loader', 'css-loader'],
       },
       {
         test: /\.(png|svg|jpg|gif)$/,
-        use: [
-          'file-loader',
-        ],
+        use: ['file-loader'],
       },
       {
         test: /\.(ts|tsx)$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7006,9 +7006,9 @@ watch@~0.18.0:
     exec-sh "^0.2.0"
     minimist "^1.2.0"
 
-watchpack@^1.5.0:
+watchpack@^1.5.0, watchpack@^1.6.0:
   version "1.6.0"
-  resolved "http://registry.npm.taobao.org/watchpack/download/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
+  resolved "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
   dependencies:
     chokidar "^2.0.2"
     graceful-fs "^4.1.2"
@@ -7072,13 +7072,6 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0:
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
-
-webpack-watch-files-plugin@^1.0.2:
-  version "1.0.2"
-  resolved "http://registry.npm.taobao.org/webpack-watch-files-plugin/download/webpack-watch-files-plugin-1.0.2.tgz#f134f6729e10a39d928282c699a659b81ab0b6e6"
-  dependencies:
-    glob "^7.1.2"
-    lodash "^4.17.5"
 
 webpack@^4.12.0:
   version "4.12.0"


### PR DESCRIPTION
Close #33 
* Use `watchpack` replace `webpack-watch-files-plugin` as it is maintained by webpack official.
* Turn on webpack `development` mode for fast compiling.