### PR TITLE
chore: Make CI build master branch only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 language: node_js
+
 sudo: false
+
 node_js:
   - "6"
   - "7"
   - "8"
   - "9"
   - "10"
+
+branches:
+  only:
+    - master
+
 script:
- - yarn lint
- - yarn test
+  - yarn lint
+  - yarn test
+
 cache: yarn


### PR DESCRIPTION
Since we have adopted a newer and simpler way of team collaboration, it can save pretty much time to skip building branches other than master.